### PR TITLE
Use pycodestyle as it was renamed from pep8

### DIFF
--- a/{{cookiecutter.package_name}}/Pipfile
+++ b/{{cookiecutter.package_name}}/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [dev-packages]
 pytest = "*"
-"pytest-pep8" = "*"
+pytest-pycodestyle = "*"
 pytest-flakes = "*"
 pytest-isort = "*"
 pytest-django = "*"

--- a/{{cookiecutter.package_name}}/setup.cfg
+++ b/{{cookiecutter.package_name}}/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -vs --tb=short --pep8 --isort --flakes --nomigrations
+addopts = -vs --tb=short --codestyle --isort --flakes --nomigrations
 
 testpaths =
 	{{ cookiecutter.module_name }}
@@ -10,7 +10,7 @@ python_files =
 
 cov_report = term-missing
 
-pep8maxlinelength = 96
+codestyle_max_line_length = 96
 
 DJANGO_SETTINGS_MODULE = tests.settings
 


### PR DESCRIPTION
pep8 was renamed to pycodestyle and pep8 is incompatible with python typehints